### PR TITLE
Remove all resources after destruction of the stack

### DIFF
--- a/pkg/stacks/authorizer/efs.go
+++ b/pkg/stacks/authorizer/efs.go
@@ -8,11 +8,18 @@ import (
 )
 
 func createEFSWithAccessPoint(stack awscdk.Stack, vpc awsec2.IVpc) awsefs.AccessPoint {
-	fs := awsefs.NewFileSystem(stack, jsii.String("AuthorizerConfigurationFileSystem"), &awsefs.FileSystemProps{
-		Vpc: vpc,
+
+	var (
+		fs awsefs.FileSystem
+		ap awsefs.AccessPoint
+	)
+
+	fs = awsefs.NewFileSystem(stack, jsii.String("AuthorizerConfigurationFileSystem"), &awsefs.FileSystemProps{
+		Vpc:           vpc,
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
 	})
 
-	return fs.AddAccessPoint(jsii.String("EFSAccessPoint"), &awsefs.AccessPointOptions{
+	ap = fs.AddAccessPoint(jsii.String("EFSAccessPoint"), &awsefs.AccessPointOptions{
 		Path: jsii.String(EfsApPath),
 		CreateAcl: &awsefs.Acl{
 			OwnerGid:    jsii.String("1001"), // Using POSIX user and group
@@ -24,4 +31,7 @@ func createEFSWithAccessPoint(stack awscdk.Stack, vpc awsec2.IVpc) awsefs.Access
 			Gid: jsii.String("1001"),
 		},
 	})
+	ap.ApplyRemovalPolicy(awscdk.RemovalPolicy_DESTROY)
+
+	return ap
 }

--- a/pkg/stacks/authorizer/stack.go
+++ b/pkg/stacks/authorizer/stack.go
@@ -56,7 +56,8 @@ func getVpc(stack awscdk.Stack, vpcID string) awsec2.IVpc {
 		return awsec2.Vpc_FromLookup(stack, jsii.String("VPC"), &awsec2.VpcLookupOptions{
 			VpcId: jsii.String(vpcID),
 		})
-	} else {
-		return awsec2.NewVpc(stack, jsii.String("VPC"), &awsec2.VpcProps{})
-	}
+	} 
+	vpc := awsec2.NewVpc(stack, jsii.String("VPC"), &awsec2.VpcProps{})
+	vpc.ApplyRemovalPolicy(awscdk.RemovalPolicy_DESTROY)
+	return vpc
 }

--- a/pkg/stacks/authorizer/sync_trigger.go
+++ b/pkg/stacks/authorizer/sync_trigger.go
@@ -45,6 +45,7 @@ func createDirectEventBridgeRule(stack awscdk.Stack, lambda awslambda.Function) 
 func createSQSQueue(stack awscdk.Stack) awssqs.Queue {
 	deadLetterQueue := awssqs.NewQueue(stack, jsii.String("DeadLetterQueue"), &awssqs.QueueProps{
 		RetentionPeriod: awscdk.Duration_Minutes(jsii.Number(1)),
+		RemovalPolicy:   awscdk.RemovalPolicy_DESTROY,
 	})
 
 	return awssqs.NewQueue(stack, jsii.String("SQSQueue"), &awssqs.QueueProps{
@@ -53,6 +54,7 @@ func createSQSQueue(stack awscdk.Stack) awssqs.Queue {
 			Queue:           deadLetterQueue,
 			MaxReceiveCount: jsii.Number(1),
 		},
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
 	})
 }
 
@@ -77,6 +79,7 @@ func createStateMachine(stack awscdk.Stack, queue awssqs.Queue, props StackProps
 
 	return awsstepfunctions.NewStateMachine(stack, jsii.String("Sync Looper"), &awsstepfunctions.StateMachineProps{
 		DefinitionBody: awsstepfunctions.ChainDefinitionBody_FromChainable(definition),
+		RemovalPolicy:  awscdk.RemovalPolicy_DESTROY,
 	})
 }
 
@@ -85,4 +88,5 @@ func createEventBridgeRule(stack awscdk.Stack, syncLooper awsstepfunctions.State
 		Schedule: awsevents.Schedule_Rate(awscdk.Duration_Minutes(jsii.Number(EventBridgeTriggerIntervalMinutes))),
 	})
 	rule.AddTarget(awseventstargets.NewSfnStateMachine(syncLooper, &awseventstargets.SfnStateMachineProps{}))
+	rule.ApplyRemovalPolicy(awscdk.RemovalPolicy_DESTROY)
 }


### PR DESCRIPTION
Deletion of the stack will remove all resources.

Applied DESTROY removal policy for all stateful resources.