### PR TITLE
Change the default visibility timeout for sqs

### DIFF
--- a/pkg/stacks/authorizer/sync_trigger.go
+++ b/pkg/stacks/authorizer/sync_trigger.go
@@ -48,7 +48,7 @@ func createSQSQueue(stack awscdk.Stack) awssqs.Queue {
 	})
 
 	return awssqs.NewQueue(stack, jsii.String("SQSQueue"), &awssqs.QueueProps{
-		VisibilityTimeout: awscdk.Duration_Seconds(jsii.Number(10)),
+		VisibilityTimeout: awscdk.Duration_Seconds(jsii.Number(30)),
 		DeadLetterQueue: &awssqs.DeadLetterQueue{
 			Queue:           deadLetterQueue,
 			MaxReceiveCount: jsii.Number(1),


### PR DESCRIPTION
Default visibility timeout was set to 10 seconds, which is lower then sync lambda's default timeout.
This updates SQS timeout to match the lambda one.

Reported in https://github.com/cloudentity/aws-authorizer-cdk/issues/3